### PR TITLE
Fix: get data range by datetime not messageid to get oldest and latest message

### DIFF
--- a/src/service/rawInfo.service.ts
+++ b/src/service/rawInfo.service.ts
@@ -41,8 +41,8 @@ const checkExist = async (connection: Connection, time: Date) => {
 
 const getRangeId = async (connection: Connection) => {
   const model = connection.models.RawInfo;
-  const latest = await model.findOne().sort({ messageId: -1 });
-  const oldest = await model.findOne().sort({ messageId: 1 });
+  const latest = await model.findOne().sort({ datetime: -1 });
+  const oldest = await model.findOne().sort({ datetime: 1 });
   return [oldest, latest];
 };
 


### PR DESCRIPTION
When use messageid, it is sorting had a problem